### PR TITLE
[JENKINS-41297] jquery plugin vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.424</version>
+    <version>2.25</version>
   </parent>
 
   <artifactId>jquery</artifactId>
@@ -12,6 +12,12 @@
   <packaging>hpi</packaging>
   <name>Jenkins jQuery plugin</name>
   <url>http://wiki.jenkins-ci.org/display/JENKINS/jQuery+Plugin</url>
+
+  <properties>
+    <jenkins.version>1.625</jenkins.version>
+    <jenkins-test-harness.version>1.625</jenkins-test-harness.version>
+    <java.level>6</java.level>
+  </properties>
 
   <developers>
     <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
   <url>http://wiki.jenkins-ci.org/display/JENKINS/jQuery+Plugin</url>
 
   <properties>
-    <jenkins.version>1.625</jenkins.version>
-    <java.level>6</java.level>
+    <jenkins.version>1.625.3</jenkins.version>
+    <java.level>7</java.level>
   </properties>
 
   <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,6 @@
 
   <properties>
     <jenkins.version>1.625</jenkins.version>
-    <jenkins-test-harness.version>1.625</jenkins-test-harness.version>
     <java.level>6</java.level>
   </properties>
 
@@ -63,4 +62,4 @@
         <comments>All source code is under the MIT license.</comments>
       </license>
     </licenses>
-</project>  
+</project>

--- a/src/main/resources/hudson/plugins/jquery/JQuery/header.jelly
+++ b/src/main/resources/hudson/plugins/jquery/JQuery/header.jelly
@@ -1,3 +1,5 @@
+<?jelly escape-by-default='true'?>
+
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
   <st:adjunct includes="org.kohsuke.stapler.jquery" />
   <!-- avoid conflict with prototype.js in core -->

--- a/src/main/resources/hudson/plugins/jquery/colorbox.jelly
+++ b/src/main/resources/hudson/plugins/jquery/colorbox.jelly
@@ -1,3 +1,5 @@
+<?jelly escape-by-default='true'?>
+
 <!--
 Use it like <st:adjunct includes="hudson.plugins.jquery.colorbox"/>
 -->

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,5 @@
+<?jelly escape-by-default='true'?>
+
 <div>
   This allows other plugins to use jQuery in UI.
 </div>


### PR DESCRIPTION
[JENKINS-41297](https://issues.jenkins-ci.org/browse/JENKINS-41297)

This PR updates the parent pom to latest version, it also provides a small baseline bump to `1.625` which I believe is reasonable enough for backwards compatibility. 

The final result is that `commons-fileupload 1.3.1` and the newest parent pom are used whilst there are no big changes in code, just a java level update to 6 which I can hardly believe is too disruptive.

Also I have added the `escape-by-default` jelly tag  

@reviewbybees 