### PR TITLE
Update plugin POM

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.0-beta-7</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.2</version>
+    <version>3.48</version>
   </parent>
 
   <artifactId>jquery</artifactId>
@@ -12,11 +12,11 @@
   <packaging>hpi</packaging>
   <name>jQuery plugin</name>
   <description>This plugin provides an stable version of jQuery Javascript Library</description>
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/jQuery+Plugin</url>
+  <url>https://wiki.jenkins.io/display/JENKINS/jQuery+Plugin</url>
 
   <properties>
-    <jenkins.version>1.625.3</jenkins.version>
-    <java.level>7</java.level>
+    <jenkins.version>2.60.3</jenkins.version>
+    <java.level>8</java.level>
   </properties>
 
   <developers>
@@ -33,13 +33,14 @@
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
   </repositories>
 
   <scm>
-    <connection>scm:git:git@github.com:jenkinsci/jquery-plugin.git</connection>
-    <developerConnection>scm:git:git@github.com:jenkinsci/jquery-plugin.git</developerConnection>
+    <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
+    <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
+    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
     <tag>HEAD</tag>
   </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,13 +8,15 @@
   </parent>
 
   <artifactId>jquery</artifactId>
-  <version>1.12.4-1-SNAPSHOT</version>
+  <version>${revision}${changelist}</version>
   <packaging>hpi</packaging>
   <name>jQuery plugin</name>
   <description>This plugin provides an stable version of jQuery Javascript Library</description>
   <url>https://wiki.jenkins.io/display/JENKINS/jQuery+Plugin</url>
 
   <properties>
+    <revision>1.12.4-1</revision>
+    <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.60.3</jenkins.version>
     <java.level>8</java.level>
   </properties>
@@ -41,7 +43,7 @@
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-    <tag>HEAD</tag>
+    <tag>${scmTag}</tag>
   </scm>
 
   <dependencies>


### PR DESCRIPTION
Bump the plugin parent POM from 3.2 to 3.48. See [the changelog](https://github.com/jenkinsci/plugin-pom/blob/master/CHANGELOG.md) and the full diff in [the compare view](https://github.com/jenkinsci/plugin-pom/compare/plugin-3.2...plugin-3.48).

While I was here, I modernized the plugin by updating to Java 8 and Jenkins core 2.60.3 or later. Java 7 support is likely to be dropped from newer versions of the plugin POM soon, so this move future-proofs this plugin for further POM updates. I also incrementalified the plugin.