### PR TITLE
Build with both JDK 8 and JDK 11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin()
+buildPlugin(configurations: buildPlugin.recommendedConfigurations())


### PR DESCRIPTION
Build this plugin with both JDK 8 and JDK 11. This goes with the Jenkins Java 11 General Availability announcement made back in March. See [the Java 11 Developer Guidelines](https://wiki.jenkins.io/display/JENKINS/Java+11+Developer+Guidelines#Java11DeveloperGuidelines-MakesureyourpluginistestedinContinuousIntegrationonJava8andJava11atthesametime) for an explanation of the `Jenkinsfile` changes.